### PR TITLE
feat: add missing hourly SCM polling trigger to Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,6 +12,10 @@ pipeline {
         DOCKERFILE = 'Dockerfile'
     }
 
+    triggers {
+        pollSCM('H * * * *')
+    }
+
     stages {
         stage('Initialize GitHub Status') {
             when {


### PR DESCRIPTION
This Pull Request re-introduces the hourly SCM polling trigger that was missed in the previous automation merge. This aligns the repository with the project's standard pipeline configuration.

Closes #7