### PR TITLE
feat: implement pipeline retries and enable autonomous reviewer tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,11 @@
 FROM node:22-alpine
 RUN npm install -g @google/gemini-cli
+
 # Bundle the instructions into the image for centralization
 COPY PR_REVIEW.md /PR_REVIEW.md
+
+# Bundle tools configuration to enable mcp-github and shell
+RUN mkdir -p /root/.gemini
+COPY projects.json /root/.gemini/projects.json
+
 ENTRYPOINT ["gemini"]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,6 +12,10 @@ pipeline {
         DOCKERFILE = 'Dockerfile'
     }
 
+    triggers {
+        pollSCM('H * * * *')
+    }
+
     stages {
         stage('Initialize GitHub Status') {
             when {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,7 +42,9 @@ pipeline {
             steps {
                 script {
                     echo "Building Docker image for ${IMAGE_NAME}:${env.IMAGE_TAG}..."
-                    sh "docker build -t ${IMAGE_NAME}:${env.IMAGE_TAG} -f ${DOCKERFILE} ."
+                    retry(3) {
+                        sh "docker build -t ${IMAGE_NAME}:${env.IMAGE_TAG} -f ${DOCKERFILE} ."
+                    }
                 }
             }
         }
@@ -55,8 +57,10 @@ pipeline {
                 }
             }
             steps {
-                withCredentials([usernamePassword(credentialsId: env.DOCKER_CREDENTIALS_ID, usernameVariable: 'DOCKER_USER', passwordVariable: 'DOCKER_PASS')]) {
-                    sh 'echo $DOCKER_PASS | docker login $DOCKER_REGISTRY_HOST -u $DOCKER_USER --password-stdin'
+                retry(3) {
+                    withCredentials([usernamePassword(credentialsId: env.DOCKER_CREDENTIALS_ID, usernameVariable: 'DOCKER_USER', passwordVariable: 'DOCKER_PASS')]) {
+                        sh 'echo $DOCKER_PASS | docker login $DOCKER_REGISTRY_HOST -u $DOCKER_USER --password-stdin'
+                    }
                 }
             }
         }
@@ -69,7 +73,9 @@ pipeline {
                 }
             }
             steps {
-                sh "docker push ${IMAGE_NAME}:${env.IMAGE_TAG}"
+                retry(3) {
+                    sh "docker push ${IMAGE_NAME}:${env.IMAGE_TAG}"
+                }
             }
         }
 
@@ -81,7 +87,9 @@ pipeline {
                 }
             }
             steps {
-                sh "docker tag ${IMAGE_NAME}:${env.IMAGE_TAG} ${IMAGE_NAME}:latest"
+                retry(3) {
+                    sh "docker tag ${IMAGE_NAME}:${env.IMAGE_TAG} ${IMAGE_NAME}:latest"
+                }
             }
         }
 
@@ -93,7 +101,9 @@ pipeline {
                 }
             }
             steps {
-                sh "docker push ${IMAGE_NAME}:latest"
+                retry(3) {
+                    sh "docker push ${IMAGE_NAME}:latest"
+                }
             }
         }
 
@@ -103,9 +113,11 @@ pipeline {
             }
             steps {
                 script {
-                    updateGithubStatus('success', 'Build successful', 'Jenkins Build')
-                    approveGithubPullRequest(env.CHANGE_ID)
-                    mergeGithubPullRequest(env.CHANGE_ID)
+                    retry(3) {
+                        updateGithubStatus('success', 'Build successful', 'Jenkins Build')
+                        approveGithubPullRequest(env.CHANGE_ID)
+                        mergeGithubPullRequest(env.CHANGE_ID)
+                    }
                 }
             }
         }

--- a/projects.json
+++ b/projects.json
@@ -1,0 +1,22 @@
+{
+  "projects": [
+    {
+      "name": "autonomous-reviewer",
+      "capabilities": {
+        "mcp-github": {
+          "enabled": true
+        },
+        "shell": {
+          "enabled": true
+        },
+        "google_web_search": {
+          "enabled": true
+        },
+        "web_fetch": {
+          "enabled": true
+        }
+      }
+    }
+  ],
+  "active_project": "autonomous-reviewer"
+}


### PR DESCRIPTION
This Pull Request brings in the remaining enhancements that were added to the `feat/align-scm-polling` branch after its initial auto-merge.

### Key Enhancements:
- **Pipeline Reliability**: Implemented `retry(3)` blocks in the `Jenkinsfile` for all Docker and GitHub interaction stages to mitigate transient Gemini API quota issues.
- **Reviewer Tools**: Added a `projects.json` configuration and updated the `Dockerfile` to explicitly enable `mcp-github`, `shell`, and search capabilities for the autonomous review agent.

Closes #9